### PR TITLE
Porting Aseba (VM & CAN interface)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ include $(CHIBIOS)/os/hal/osal/rt/osal.mk
 include $(CHIBIOS)/os/rt/rt.mk
 include $(CHIBIOS)/os/rt/ports/ARMCMx/compilers/GCC/mk/port_stm32f4xx.mk
 include $(CHIBIOS)/test/rt/test.mk
-include src/aseba.mk
+include src/aseba_vm/aseba.mk
 include src/src.mk
 
 # Define linker script file here
@@ -107,6 +107,7 @@ CSRC = $(PORTSRC) \
        $(CHIBIOS)/os/various/shell.c \
        $(CHIBIOS)/os/hal/lib/streams/memstreams.c \
        $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
+       $(ASEBASRC) \
        $(SRC)
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
@@ -140,6 +141,7 @@ INCDIR = $(PORTINC) $(KERNINC) $(TESTINC) \
          $(HALINC) $(OSALINC) $(PLATFORMINC) $(BOARDINC) \
          $(CHIBIOS)/os/various \
          $(CHIBIOS)/os/hal/lib/streams \
+         $(ASEBAINC) \
          src/ \
          src/board/
 

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ CPPC = $(TRGT)g++
 #       runtime support makes code size explode.
 LD   = $(TRGT)gcc
 #LD   = $(TRGT)g++
-CP   = $(TRGT)objcopy
+CP   = $(TRGT)objcopy -j startup -j constructors -j destructors -j .text -j .ARM.extab -j .ARM.exidx -j .eh_frame_hdr -j .eh_frame -j .textalign -j .data
 AS   = $(TRGT)gcc -x assembler-with-cpp
 AR   = $(TRGT)ar
 OD   = $(TRGT)objdump

--- a/src/aseba.mk
+++ b/src/aseba.mk
@@ -1,8 +1,0 @@
-ASEBA = ../aseba
-
-ASEBASRC = $(ASEBA)/transport/buffer/vm-buffer.c \
-		   $(ASEBA)/vm/natives.c \
-		   $(ASEBA)/vm/vm.c
-
-ASEBAINC = $(ASEBA)/transport/buffer \
-		   $(ASEBA)/vm

--- a/src/aseba_vm/aseba.mk
+++ b/src/aseba_vm/aseba.mk
@@ -1,0 +1,12 @@
+ASEBA = ./aseba
+
+ASEBASRC = $(ASEBA)/transport/buffer/vm-buffer.c \
+           $(ASEBA)/transport/can/can-buffer.c \
+           $(ASEBA)/transport/can/can-net.c \
+           $(ASEBA)/vm/natives.c \
+           $(ASEBA)/vm/vm.c \
+           src/aseba_vm/aseba_can_interface.c \
+           src/aseba_vm/aseba_node.c \
+           src/aseba_vm/skel.c
+
+ASEBAINC = $(ASEBA)

--- a/src/aseba_vm/aseba_can_interface.c
+++ b/src/aseba_vm/aseba_can_interface.c
@@ -59,15 +59,13 @@ static THD_FUNCTION(can_rx_thread, arg) {
 
 void can_init(void)
 {
-#if defined(BOARD_ST_STM32F4_DISCOVERY)
     // CAN1 gpio init
     iomode_t mode = PAL_STM32_MODE_ALTERNATE | PAL_STM32_OTYPE_PUSHPULL
         | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUDR_FLOATING
         | PAL_STM32_ALTERNATE(9);
-    palSetPadMode(GPIOD, GPIOD_PIN0, mode); // RX
-    palSetPadMode(GPIOD, GPIOD_PIN1, mode); // TX
+    palSetPadMode(GPIOD, GPIOD_CAN_RX, mode); // RX
+    palSetPadMode(GPIOD, GPIOD_CAN_TX, mode); // TX
     canStart(&CAND1, &can1_config);
-#endif
 }
 
 void aseba_can_rx_dropped(void)

--- a/src/aseba_vm/aseba_can_interface.c
+++ b/src/aseba_vm/aseba_can_interface.c
@@ -1,0 +1,113 @@
+#include "ch.h"
+#include "hal.h"
+
+#include "transport/can/can-net.h"
+#include "vm/vm.h"
+
+#include "aseba_can_interface.h"
+
+#define ASEBA_CAN_SEND_QUEUE_SIZE       1024
+#define ASEBA_CAN_RECEIVE_QUEUE_SIZE    1024
+
+
+static const CANConfig can1_config = {
+    .mcr = (1 << 6)  /* Automatic bus-off management enabled. */
+         | (1 << 2), /* Message are prioritized by order of arrival. */
+
+    /* APB Clock is 42 Mhz
+       42MHz / 2 / (1tq + 12tq + 8tq) = 1MHz => 1Mbit */
+    .btr = (1 << 0)  /* Baudrate prescaler (10 bits) */
+         | (11 << 16)/* Time segment 1 (3 bits) */
+         | (7 << 20) /* Time segment 2 (3 bits) */
+         | (0 << 24) /* Resync jump width (2 bits) */
+
+#if 0
+         | (1 << 30) /* Loopback mode enabled */
+#endif
+};
+
+CanFrame aseba_can_send_queue[ASEBA_CAN_SEND_QUEUE_SIZE];
+CanFrame aseba_can_receive_queue[ASEBA_CAN_RECEIVE_QUEUE_SIZE];
+
+static THD_WORKING_AREA(can_rx_thread_wa, 256);
+static THD_FUNCTION(can_rx_thread, arg) {
+    (void)arg;
+    chRegSetThreadName("CAN rx");
+    while (1) {
+        CANRxFrame rxf;
+        CanFrame aseba_can_frame;
+        msg_t m = canReceive(&CAND1, CAN_ANY_MAILBOX, &rxf, MS2ST(1000));
+        if (m != MSG_OK) {
+            continue;
+        }
+        if (rxf.IDE) {
+            continue; // no extended id frames
+        }
+        if (rxf.RTR) {
+            continue; // no remote transmission request frames
+        }
+        aseba_can_frame.id = rxf.SID;
+        aseba_can_frame.len = rxf.DLC;
+        int i;
+        for (i = 0; i < aseba_can_frame.len; i++) {
+            aseba_can_frame.data[i] = rxf.data8[i];
+        }
+        AsebaCanFrameReceived(&aseba_can_frame);
+    }
+    return 0;
+}
+
+void can_init(void)
+{
+#if defined(BOARD_ST_STM32F4_DISCOVERY)
+    // CAN1 gpio init
+    iomode_t mode = PAL_STM32_MODE_ALTERNATE | PAL_STM32_OTYPE_PUSHPULL
+        | PAL_STM32_OSPEED_HIGHEST | PAL_STM32_PUDR_FLOATING
+        | PAL_STM32_ALTERNATE(9);
+    palSetPadMode(GPIOD, GPIOD_PIN0, mode); // RX
+    palSetPadMode(GPIOD, GPIOD_PIN1, mode); // TX
+    canStart(&CAND1, &can1_config);
+#endif
+}
+
+void aseba_can_rx_dropped(void)
+{
+}
+
+void aseba_can_tx_dropped(void)
+{
+}
+
+void aseba_can_send_frame(const CanFrame *frame)
+{
+    CANTxFrame txf;
+    txf.DLC = frame->len;
+    txf.RTR = 0;
+    txf.IDE = 0;
+    txf.SID = frame->id;
+
+    int i;
+    for (i = 0; i < frame->len; i++) {
+        txf.data8[i] = frame->data[i];
+    }
+
+    canTransmit(&CAND1, CAN_ANY_MAILBOX, &txf, MS2ST(100));
+    chThdSleepMilliseconds(1);
+    AsebaCanFrameSent();
+}
+
+// Returns true if there is enough space to send the frame
+int aseba_can_is_frame_room(void)
+{
+    return can_lld_is_tx_empty(&CAND1, CAN_ANY_MAILBOX);
+}
+
+void aseba_can_start(AsebaVMState *vm_state)
+{
+    can_init();
+    chThdCreateStatic(can_rx_thread_wa, sizeof(can_rx_thread_wa), NORMALPRIO+1, can_rx_thread, NULL);
+    AsebaCanInit(vm_state->nodeId, aseba_can_send_frame, aseba_can_is_frame_room,
+                aseba_can_rx_dropped, aseba_can_tx_dropped,
+                aseba_can_send_queue, ASEBA_CAN_SEND_QUEUE_SIZE,
+                aseba_can_receive_queue, ASEBA_CAN_RECEIVE_QUEUE_SIZE);
+}

--- a/src/aseba_vm/aseba_can_interface.h
+++ b/src/aseba_vm/aseba_can_interface.h
@@ -1,0 +1,16 @@
+#ifndef ASEBA_CAN_INTERFACE_H
+#define ASEBA_CAN_INTERFACE_H
+
+#include "vm/vm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void aseba_can_start(AsebaVMState *vm_state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASEBA_CAN_INTERFACE_H */

--- a/src/aseba_vm/aseba_node.c
+++ b/src/aseba_vm/aseba_node.c
@@ -1,0 +1,71 @@
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+#include "usbcfg.h"
+
+#include "common/consts.h"
+#include "common/productids.h"
+#include "vm/vm.h"
+#include "aseba_vm/skel.h"
+#include "aseba_vm/skel_user.h"
+#include "aseba_vm/aseba_node.h"
+
+
+void update_aseba_variables_read(void);
+void update_aseba_variables_write(void);
+
+static THD_WORKING_AREA(aseba_vm_thd_wa, 1024);
+static THD_FUNCTION(aseba_vm_thd, arg)
+{
+    (void)arg;
+
+    AsebaVMSetupEvent(&vmState, ASEBA_EVENT_INIT);
+
+    while (TRUE) {
+        // Don't spin too fast to avoid consuming all CPU time
+        chThdSleepMilliseconds(10);
+
+        // Sync Aseba with the state of the Microcontroller
+        update_aseba_variables_read();
+
+        // Run VM for some time
+        AsebaVMRun(&vmState, 1000);
+        AsebaProcessIncomingEvents(&vmState);
+
+        // Sync the Microcontroller with the state of Aseba
+        update_aseba_variables_write();
+    }
+    return 0;
+}
+
+void aseba_vm_init(void)
+{
+    vmState.nodeId = 3;
+
+    AsebaVMInit(&vmState);
+    vmVariables.id = vmState.nodeId;
+    vmVariables.productId = ASEBA_PID_UNDEFINED;
+    vmVariables.fwversion[0] = 0;
+    vmVariables.fwversion[1] = 1;
+
+    chThdSleepMilliseconds(500);
+
+    AsebaVMSetupEvent(&vmState, ASEBA_EVENT_INIT);
+}
+
+void aseba_vm_start(void)
+{
+    chThdCreateStatic(aseba_vm_thd_wa, sizeof(aseba_vm_thd_wa), LOWPRIO, aseba_vm_thd, NULL);
+}
+
+// This function must update the variable to match the microcontroller state
+void update_aseba_variables_read(void)
+{
+
+}
+
+// This function must update the microcontrolleur state to match the variables
+void update_aseba_variables_write(void)
+{
+
+}

--- a/src/aseba_vm/aseba_node.h
+++ b/src/aseba_vm/aseba_node.h
@@ -1,0 +1,14 @@
+#ifndef ASEBA_NODE_H
+#define ASEBA_NODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void aseba_vm_start(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/aseba_vm/skel.c
+++ b/src/aseba_vm/skel.c
@@ -1,0 +1,88 @@
+#include <string.h>
+
+// ChibiOS includes
+#include "ch.h"
+#include "hal.h"
+
+// Aseba includes
+#include "vm/natives.h"
+#include "vm/vm.h"
+#include "common/consts.h"
+#include "transport/buffer/vm-buffer.h"
+
+#include "aseba_vm/skel.h"
+#include "aseba_vm/skel_user.c"
+
+unsigned int events_flags = 0;
+
+
+/*
+ * VM
+ */
+struct _vmVariables vmVariables;
+static uint16 vmBytecode[VM_BYTECODE_SIZE];
+static sint16 vmStack[VM_STACK_SIZE];
+
+AsebaVMState vmState = {
+    0,
+
+    VM_BYTECODE_SIZE,
+    vmBytecode,
+
+    sizeof(vmVariables) / sizeof(sint16),
+    (sint16*)&vmVariables,
+
+    VM_STACK_SIZE,
+    vmStack
+};
+
+
+/*
+ * Callbacks
+ */
+void AsebaIdle(void)
+{
+    chThdSleepMilliseconds(1);
+}
+
+void AsebaPutVmToSleep(AsebaVMState *vm)
+{
+    chThdSleepMilliseconds(1000);
+}
+
+void AsebaResetIntoBootloader(AsebaVMState *vm)
+{
+    NVIC_SystemReset();
+}
+
+void AsebaNativeFunction(AsebaVMState *vm, uint16 id)
+{
+    nativeFunctions[id](vm);
+}
+
+const AsebaNativeFunctionDescription * const * AsebaGetNativeFunctionsDescriptions(AsebaVMState *vm)
+{
+    return nativeFunctionsDescription;
+}
+
+
+const AsebaVMDescription* AsebaGetVMDescription(AsebaVMState *vm)
+{
+    return &vmDescription;
+}
+
+const AsebaLocalEventDescription * AsebaGetLocalEventsDescriptions(AsebaVMState *vm)
+{
+    return localEvents;
+}
+
+uint16 AsebaShouldDropPacket(uint16 source, const uint8* data)
+{
+    return AsebaVMShouldDropPacket(&vmState, source, data);
+}
+
+// Used to write bytecode in the flash, not implemented yet
+void AsebaWriteBytecode(AsebaVMState *vm)
+{
+
+}

--- a/src/aseba_vm/skel.h
+++ b/src/aseba_vm/skel.h
@@ -1,0 +1,42 @@
+#ifndef SKEL_H
+#define SKEL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ChibiOS includes
+#include <hal.h>
+
+// Aseba include
+#include "vm/natives.h"
+#include "vm/vm.h"
+#include "common/types.h"
+
+#include "skel_user.h"
+
+extern struct _vmVariables vmVariables;
+extern unsigned int events_flags;
+extern AsebaVMState vmState;
+
+extern char aseba_byte_code_container[VM_BYTECODE_SIZE];
+
+/*
+ * In your code, put "SET_EVENT(EVENT_NUMBER)" when you want to trigger an
+ * event. This macro is interrupt-safe, you can call it anywhere you want.
+ */
+#define SET_EVENT(event) (events_flags |= (1 << event))
+#define CLEAR_EVENT(event) (events_flags &= ~(1 << event))
+#define IS_EVENT(event) (events_flags & (1 << event))
+
+/*
+ * Call this to init aseba. Beware, this will:
+ * 1. Clear vmVariables.
+ */
+void aseba_vm_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SKEL_H */

--- a/src/aseba_vm/skel_user.c
+++ b/src/aseba_vm/skel_user.c
@@ -1,0 +1,56 @@
+#include "ch.h"
+#include "hal.h"
+
+#include "vm/natives.h"
+
+/*
+ * Descriptors
+ */
+const AsebaVMDescription vmDescription = {
+	"Epuck2",
+	{
+		// {Number of element in array, Name displayed in aseba studio}
+		{1, "_id"},
+		{1, "event.source"},
+		{VM_VARIABLES_ARG_SIZE, "event.args"},
+		{2, "_fwversion"},
+		{1, "_productId"},
+
+        {1, "led"},
+
+		{0, NULL}
+	}
+};
+
+// Event descriptions
+static const AsebaLocalEventDescription localEvents[] = {
+    {NULL, NULL}
+};
+
+// Native functions
+static AsebaNativeFunctionDescription AsebaNativeDescription__system_reboot =
+{
+    "_system.reboot",
+    "Reboot the microcontroller",
+    {
+        {0,0}
+    }
+};
+
+void AsebaNative__system_reboot(AsebaVMState *vm)
+{
+    NVIC_SystemReset();
+}
+
+// Native function descriptions
+static const AsebaNativeFunctionDescription* nativeFunctionsDescription[] = {
+	&AsebaNativeDescription__system_reboot,
+    ASEBA_NATIVES_STD_DESCRIPTIONS,
+    0
+};
+
+// Native function pointers
+static AsebaNativeFunctionPointer nativeFunctions[] = {
+    AsebaNative__system_reboot,
+	ASEBA_NATIVES_STD_FUNCTIONS,
+};

--- a/src/aseba_vm/skel_user.h
+++ b/src/aseba_vm/skel_user.h
@@ -1,0 +1,70 @@
+#ifndef SKEL_USER_H
+#define SKEL_USER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Send queue size may be smaller (64 is the smallest value) something like 70-80 is better
+ * 128 is luxury
+ */
+#define SEND_QUEUE_SIZE 128
+
+/*
+ * Warning, at least an aseba message MUST be able to fit into this RECV_QUEUE_SIZE buffer
+ * 256 is IMHO the minimum, but maybe it can be lowered with a lot of caution.
+ * The bigger you have, the best it is. Fill the empty ram with it :)
+ */
+#define RECV_QUEUE_SIZE 756
+
+/*
+ * This is the number of "private" variable the aseba script can have
+ */
+#define VM_VARIABLES_FREE_SPACE 256
+
+/*
+ * This is the maximum number of argument an aseba event can receive
+ */
+#define VM_VARIABLES_ARG_SIZE 32
+
+/*
+ * The number of opcode an aseba script can have
+ */
+#define VM_BYTECODE_SIZE (766 + 768)  // PUT HERE 766 + 768 * a, where a is >= 0
+#define VM_STACK_SIZE 128
+
+
+struct _vmVariables {
+	sint16 id; 							// NodeID
+	sint16 source; 						// Source
+	sint16 args[VM_VARIABLES_ARG_SIZE]; // Args
+	sint16 fwversion[2];				// Firmware version
+	sint16 productId;					// Product ID
+
+	// Free space
+	sint16 freeSpace[VM_VARIABLES_FREE_SPACE];
+};
+
+
+enum Events
+{
+	EVENTS_COUNT   // Do not touch
+};
+
+// The content of this structure is implementation-specific.
+// The glue provide a way to store and retrive it from flash.
+// The only way to write it is to do it from inside the VM (native function)
+// The native function access it as a integer array. So, use only int inside this structure
+struct private_settings {
+	/* ADD here the settings to save into flash */
+	/* The minimum size is one integer, the maximum size is 95 integer (Check done at compilation) */
+	int settings[95];
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SKEL_USER_H */

--- a/src/halconf.h
+++ b/src/halconf.h
@@ -48,7 +48,7 @@
  * @brief   Enables the CAN subsystem.
  */
 #if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
-#define HAL_USE_CAN                 FALSE
+#define HAL_USE_CAN                 TRUE
 #endif
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,10 @@
 #include "cmd.h"
 #include "control.h"
 
+#include "aseba_vm/skel.h"
+#include "aseba_vm/aseba_node.h"
+#include "aseba_vm/aseba_can_interface.h"
+
 
 #define SHELL_WA_SIZE   THD_WORKING_AREA_SIZE(2048)
 
@@ -20,7 +24,7 @@ static THD_FUNCTION(Thread1, arg) {
   (void)arg;
   chRegSetThreadName("Heartbeat");
   while (TRUE) {
-    palSetPad(GPIOE, GPIOE_LED_HEARTBEAT);       
+    palSetPad(GPIOE, GPIOE_LED_HEARTBEAT);
     chThdSleepMilliseconds(300);
     palClearPad(GPIOE, GPIOE_LED_HEARTBEAT);
     chThdSleepMilliseconds(300);
@@ -62,11 +66,12 @@ int main(void) {
 
     chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
 
-    test_function();
+    // Initialise Aseba CAN and VM
+    aseba_vm_init();
+    aseba_can_start(&vmState);
+    aseba_vm_start();
 
     while (TRUE) {
         chThdSleepMilliseconds(500);
     }
 }
-
-

--- a/src/main.c
+++ b/src/main.c
@@ -38,12 +38,10 @@ void test_function(void)
 }
 
 
-
 int main(void) {
 
     halInit();
     chSysInit();
-
 
     /*
     * Initializes a serial-over-USB CDC driver.
@@ -61,12 +59,12 @@ int main(void) {
     usbStart(serusbcfg.usbp, &usbcfg);
     usbConnectBus(serusbcfg.usbp);
 
-
     chprintf((BaseSequentialStream*)&SDU1, "boot");
 
+    // Start heartbeat thread
     chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
 
-    // Initialise Aseba CAN and VM
+    // Initialise Aseba node (CAN and VM)
     aseba_vm_init();
     aseba_can_start(&vmState);
     aseba_vm_start();

--- a/src/mcuconf.h
+++ b/src/mcuconf.h
@@ -85,7 +85,7 @@
 /*
  * CAN driver system settings.
  */
-#define STM32_CAN_USE_CAN1                  FALSE
+#define STM32_CAN_USE_CAN1                  TRUE
 #define STM32_CAN_USE_CAN2                  FALSE
 #define STM32_CAN_CAN1_IRQ_PRIORITY         11
 #define STM32_CAN_CAN2_IRQ_PRIORITY         11


### PR DESCRIPTION
Runs a basic Aseba node on the EPuck 2 that communicates through the CAN interface.
There still needs to be integration of the EPuck natives functions into it.